### PR TITLE
Fix reducedDims accessor for SingleCellExperiment

### DIFF
--- a/R/make_hexbin.R
+++ b/R/make_hexbin.R
@@ -57,7 +57,7 @@ setMethod("make_hexbin", "SingleCellExperiment", function(sce,
                                             dimension_reduction = "UMAP",
                                             use_dims=c(1,2)) {
 
-  if(!is.element(dimension_reduction, names(sce@reducedDims))) {
+  if(!is.element(dimension_reduction, names(reducedDimNames(sce)))) {
     stop("Specify existing dimension reduction.")
   }
 

--- a/R/make_hexbin.R
+++ b/R/make_hexbin.R
@@ -57,7 +57,7 @@ setMethod("make_hexbin", "SingleCellExperiment", function(sce,
                                             dimension_reduction = "UMAP",
                                             use_dims=c(1,2)) {
 
-  if(!is.element(dimension_reduction, names(reducedDimNames(sce)))) {
+  if(!is.element(dimension_reduction, reducedDimNames(sce))) {
     stop("Specify existing dimension reduction.")
   }
 


### PR DESCRIPTION
Change to `reducedDimNames(sce)` to ensure specified `dimension_reduction` exists in the `SingleCellExperiment` object